### PR TITLE
Remove error-prone spaces

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 0.13.8
+sbt.version=0.13.8


### PR DESCRIPTION
I use sbt like [that one](https://github.com/twitter/algebird/blob/develop/sbt). And it fails to parse properties file with spaces.