### PR TITLE
= FIX: Showing authorship the way it was presented in the verbatim

### DIFF
--- a/src/main/scala/org/globalnames/formatters/Canonizer.scala
+++ b/src/main/scala/org/globalnames/formatters/Canonizer.scala
@@ -42,8 +42,8 @@ object Canonizer {
 
   def format(ag: AuthorsGroup): Option[String] = format(ag.authors)
 
-  def format(as: Authorship): Option[String] = as match {
-    case Authorship(authors, Some(comb), _) => format(authors).map("(" + _ + ") ") |+| format(comb)
-    case Authorship(authors, None, _) => format(authors)
+  def format(as: Authorship): Option[String] = {
+    format(as.authors).map { x => if (as.basionym) "(" + x + ")" else x } |+|
+      as.combination.flatMap(format).map(" " + _)
   }
 }

--- a/src/main/scala/org/globalnames/formatters/Normalizer.scala
+++ b/src/main/scala/org/globalnames/formatters/Normalizer.scala
@@ -56,8 +56,8 @@ object Normalizer {
       ag.year.flatMap(format).map(" " + _)
   }
 
-  def format(as: Authorship): Option[String] = as match {
-    case Authorship(authors, Some(comb), _) => format(authors).map("(" + _ + ") ") |+| format(comb)
-    case Authorship(authors, None, _) => format(authors)
+  def format(as: Authorship): Option[String] = {
+    format(as.authors).map { x => if (as.basionym) "(" + x + ")" else x } |+|
+      as.combination.flatMap(format).map(" " + _)
   }
 }

--- a/src/main/scala/org/globalnames/parser/AST.scala
+++ b/src/main/scala/org/globalnames/parser/AST.scala
@@ -76,4 +76,5 @@ case class AuthorsGroup(
 case class Authorship(
   authors: AuthorsGroup,
   combination: Option[AuthorsGroup] = None,
+  basionym: Boolean = false,
   quality: Int = 1)

--- a/src/main/scala/org/globalnames/parser/ParserClean.scala
+++ b/src/main/scala/org/globalnames/parser/ParserClean.scala
@@ -243,7 +243,7 @@ class ParserClean extends SimpleParser {
   val combinedAuthorship2: Rule1[Authorship] = rule {
     basionymAuthorship ~ space ~ authorship1 ~>
     ((bau: Authorship, cau: Authorship) =>
-        bau.copy(combination = Some(cau.authors), quality = 1))
+        bau.copy(combination = Some(cau.authors), basionym = true, quality = 1))
   }
 
   val basionymYearMisformed: Rule1[Authorship] = rule {


### PR DESCRIPTION
Closes: https://github.com/GlobalNamesArchitecture/gnparser/issues/16