### PR TITLE
= Add script wrapper to launch gn-parser

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -33,7 +33,7 @@ lazy val root = project.in(file("."))
   .settings(noPublishingSettings: _*)
 
 lazy val parser = (project in file("./parser"))
-  .enablePlugins(BuildInfoPlugin)
+  .enablePlugins(BuildInfoPlugin, JavaAppPackaging)
   .settings(commonSettings: _*)
   .settings(
     name := "global-names-parser",
@@ -59,6 +59,8 @@ lazy val parser = (project in file("./parser"))
     ),
 
     scalacOptions in Test ++= Seq("-Yrangepos"),
+
+    mainClass in Compile := Some("org.globalnames.parser.GnParser"),
 
     initialCommands in console :=
       """import org.globalnames.parser.{ScientificNameParser => SNP, _}

--- a/project/sbt-native-packager.sbt
+++ b/project/sbt-native-packager.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.0.3")


### PR DESCRIPTION
closes #34 

To generate script run `sbt stage`. Lanch scripts for Linux and Windows then generated in `${project_root}/parser/target/universal/stage/bin/`.