### PR TITLE
= Remove `showWarnings` parameter

### DIFF
--- a/examples/java/src/main/java/Parser.java
+++ b/examples/java/src/main/java/Parser.java
@@ -3,7 +3,7 @@ import org.globalnames.parser.ScientificNameParser;
 public class Parser {
     public static void main(String[] args) {
         ScientificNameParser.Result result =
-            ScientificNameParser.instance().fromString("Homo sapiens L.", false);
+            ScientificNameParser.instance().fromString("Homo sapiens L.");
         String jsonStr = ScientificNameParser.instance().renderCompactJson(result);
         System.out.println(jsonStr);
     }

--- a/examples/jython/parser.py
+++ b/examples/jython/parser.py
@@ -1,5 +1,5 @@
 from org.globalnames.parser import ScientificNameParser
 
 snp = ScientificNameParser.instance()
-result = snp.fromString("Homo sapiens L.", False)
+result = snp.fromString("Homo sapiens L.")
 print snp.renderCompactJson(result)

--- a/parser/src/main/scala/org/globalnames/parser/ScientificNameParser.scala
+++ b/parser/src/main/scala/org/globalnames/parser/ScientificNameParser.scala
@@ -69,7 +69,7 @@ abstract class ScientificNameParser {
   def renderCompactJson(parserResult: Result): String =
     compact(json(parserResult))
 
-  def fromString(input: String, showWarnings: Boolean = false): Result = {
+  def fromString(input: String): Result = {
     val isVirus = checkVirus(input)
     val inputString = Input(input)
     if (isVirus || noParse(input)) {


### PR DESCRIPTION
Since we output all warnings in output Json, we no longer need that parameter.

**NB**: R example *must be* updated after it is merged #141!