### PR TITLE
= Remove unused sbt-plugin

### DIFF
--- a/project/sbt-ui.sbt
+++ b/project/sbt-ui.sbt
@@ -1,3 +1,0 @@
-// This plugin represents functionality that is to be added to sbt in the future
-
-addSbtPlugin("org.scala-sbt" % "sbt-core-next" % "0.1.1")


### PR DESCRIPTION
fix #142 

The reason of logging: https://github.com/sbt/sbt-core-next/issues/8. Actually, we don't use the plugin in any way. 