### PR TITLE
+ Improve parser-lib API

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,12 +225,8 @@ sbt ";project examples;run"
 
 ### Java
 
-[Java example][example-java] is an SBT subproject. To run it execute the
-command:
-
-```
-sbt ";project examples;run"
-```
+[Java example][example-java] is an SBT subproject. Run `sbt examples/run`
+to execute it.
 
 ### Jython
 

--- a/examples/R/parser.R
+++ b/examples/R/parser.R
@@ -2,5 +2,5 @@ require("rJava")
 pathToGnParserAssembly='${GnParser_PATH}/gnparser/parser/target/scala-2.11/global-names-parser-assembly-0.1.0-SNAPSHOT.jar'
 .jinit(classpath=pathToGnParserAssembly)
 snp=J('org.globalnames.parser.ScientificNameParser','instance')
-result=snp$fromString("Homo sapiens L.")
-print(snp$renderCompactJson(result))
+result=snp$fromString("Homo sapiens L.")$renderCompactJson
+print(result)

--- a/examples/java/src/main/java/Parser.java
+++ b/examples/java/src/main/java/Parser.java
@@ -2,9 +2,9 @@ import org.globalnames.parser.ScientificNameParser;
 
 public class Parser {
     public static void main(String[] args) {
-        ScientificNameParser.Result result =
-            ScientificNameParser.instance().fromString("Homo sapiens L.");
-        String jsonStr = ScientificNameParser.instance().renderCompactJson(result);
+        String jsonStr = ScientificNameParser.instance()
+                                             .fromString("Homo sapiens L.")
+                                             .renderCompactJson();
         System.out.println(jsonStr);
     }
 }

--- a/examples/jruby/parser.rb
+++ b/examples/jruby/parser.rb
@@ -2,5 +2,5 @@ require "java"
 java_import "org.globalnames.parser.ScientificNameParser"
 
 snp = ScientificNameParser.instance
-result = snp.fromString("Homo sapiens L.")
-puts snp.renderCompactJson(result)
+result = snp.fromString("Homo sapiens L.").renderCompactJson
+puts result

--- a/examples/jython/parser.py
+++ b/examples/jython/parser.py
@@ -1,5 +1,5 @@
 from org.globalnames.parser import ScientificNameParser
 
 snp = ScientificNameParser.instance()
-result = snp.fromString("Homo sapiens L.")
-print snp.renderCompactJson(result)
+result = snp.fromString("Homo sapiens L.").renderCompactJson()
+print result

--- a/parser/src/main/scala/org/globalnames/formatters/Canonizer.scala
+++ b/parser/src/main/scala/org/globalnames/formatters/Canonizer.scala
@@ -5,8 +5,7 @@ import org.globalnames.parser._
 import scalaz.{Name => _, _}
 import Scalaz._
 
-trait Canonizer {
-  parsedResult: ScientificNameParser.Result =>
+trait Canonizer { parsedResult: ScientificNameParser.Result =>
 
   def canonized(showRanks: Boolean): Option[String] = {
     def canonizedNamesGroup(namesGroup: NamesGroup): Option[String] =

--- a/parser/src/main/scala/org/globalnames/formatters/Details.scala
+++ b/parser/src/main/scala/org/globalnames/formatters/Details.scala
@@ -7,8 +7,7 @@ import org.json4s.{JObject, JString, JValue}
 
 import scalaz.Scalaz._
 
-trait Details { parsedResult: ScientificNameParser.Result
-                  with Normalizer with Canonizer =>
+trait Details { parsedResult: ScientificNameParser.Result =>
 
   def detailed: JValue = {
     def detailedNamesGroup(namesGroup: NamesGroup): JValue =

--- a/parser/src/main/scala/org/globalnames/formatters/JsonRenderer.scala
+++ b/parser/src/main/scala/org/globalnames/formatters/JsonRenderer.scala
@@ -1,0 +1,53 @@
+package org.globalnames.formatters
+
+import org.globalnames.parser.ScientificNameParser
+import org.json4s.JsonAST.{JArray, JValue}
+import org.json4s.JsonDSL._
+import org.json4s.jackson.JsonMethods._
+
+import scalaz._
+import Scalaz._
+
+trait JsonRenderer { parserResult: ScientificNameParser.Result =>
+
+  def json: JValue = {
+    val canonical = parserResult.canonized(showRanks = false)
+    val quality = canonical.map { _ => parserResult.scientificName.quality }
+    val parsed = canonical.isDefined
+    val qualityWarnings: Option[JArray] =
+      if (parserResult.warnings.isEmpty) None
+      else {
+        val warningsJArr: JArray =
+          parserResult.warnings.sorted
+            .map { w => JArray(List(w.level, w.message)) }.distinct
+        warningsJArr.some
+      }
+    val positionsJson: Option[JArray] = parsed.option {
+      parserResult.positioned.map { position =>
+        JArray(List(position.nodeName,
+          parserResult.input.verbatimPosAt(position.start),
+          parserResult.input.verbatimPosAt(position.end)))
+      }
+    }
+    val garbage = if (parserResult.scientificName.garbage.isEmpty) None
+    else parserResult.scientificName.garbage.some
+
+    render("scientific_name" -> ("id" -> parserResult.input.id) ~
+      ("parsed" -> parsed) ~
+      ("quality" -> quality) ~
+      ("quality_warnings" -> qualityWarnings) ~
+      ("parser_version" -> version) ~
+      ("verbatim" -> parserResult.input.verbatim) ~
+      ("normalized" -> parserResult.normalized) ~
+      ("canonical" -> canonical) ~
+      ("canonical_extended" -> parserResult.canonized(showRanks = true)) ~
+      ("hybrid" -> parserResult.scientificName.isHybrid) ~
+      ("surrogate" -> parserResult.scientificName.surrogate) ~
+      ("garbage" -> garbage) ~
+      ("virus" -> parserResult.scientificName.isVirus) ~
+      ("details" -> parserResult.detailed) ~
+      ("positions" -> positionsJson))
+  }
+
+  def renderCompactJson: String = compact(json)
+}

--- a/parser/src/main/scala/org/globalnames/formatters/Normalizer.scala
+++ b/parser/src/main/scala/org/globalnames/formatters/Normalizer.scala
@@ -4,7 +4,7 @@ import org.globalnames.parser._
 import scalaz.{Name => _, _}
 import Scalaz._
 
-trait Normalizer { parsedResult: ScientificNameParser.Result with Canonizer =>
+trait Normalizer { parsedResult: ScientificNameParser.Result =>
 
   def normalized: Option[String] = {
     def normalizedNamesGroup(namesGroup: NamesGroup): Option[String] = {

--- a/parser/src/test/scala/org/globalnames/parser/ScientificNameParserSpec.scala
+++ b/parser/src/test/scala/org/globalnames/parser/ScientificNameParserSpec.scala
@@ -17,10 +17,11 @@ class ScientificNameParserSpec extends Specification {
 
   for (line <- lines.takeWhile { _.trim != "__END__" } if !(line.isEmpty || ("#\r\n\f\t" contains line.charAt(0)))) {
     val Array(inputStr, expectedJsonStr) = line.split('|')
-    val parsed = scientificNameParser.fromString(inputStr)
 
     val json = parse(expectedJsonStr)
-    val jsonParsed = scientificNameParser.json(parsed).removeField { case (_, v) => v == JNothing }
+    val jsonParsed = scientificNameParser.fromString(inputStr).json
+                       .removeField { case (_, v) => v == JNothing }
+
     val jsonDiff = {
       val Diff(changed, added, deleted) = jsonParsed.diff(json)
       s"""Line:

--- a/runner/src/main/scala/org/globalnames/GnParser.scala
+++ b/runner/src/main/scala/org/globalnames/GnParser.scala
@@ -49,8 +49,7 @@ object GnParser {
           f.getLines().zipWithIndex.foreach {
             case (line, i) =>
               if ((i + 1) % 10000 == 0) println(s"Parsed ${i + 1} lines")
-              val parsed = scientificNameParser.renderCompactJson(
-                scientificNameParser.fromString(line.trim))
+              val parsed = scientificNameParser.fromString(line.trim).renderCompactJson
               writer.write(parsed + "\n")
           }
       }
@@ -68,8 +67,7 @@ object GnParser {
         val output = if (o.contains('output)) o('output) else "output.json"
         startFileParse(input, output)
       case o if o.contains('name) =>
-        println(scientificNameParser.renderCompactJson(
-          scientificNameParser.fromString(o('name))))
+        println(scientificNameParser.fromString(o('name)).renderCompactJson)
     }
   }
 }

--- a/runner/src/main/scala/org/globalnames/ParServer.scala
+++ b/runner/src/main/scala/org/globalnames/ParServer.scala
@@ -15,8 +15,7 @@ case class ParServer(port: Int = 4334) {
     val output = new PrintStream(new BufferedOutputStream(sock.getOutputStream))
     while (true) {
       line = input.readLine.trim
-      output.println(scientificNameParser.renderCompactJson(
-        scientificNameParser.fromString(line)))
+      output.println(scientificNameParser.fromString(line).renderCompactJson)
       output.flush()
     }
   }

--- a/web/app/controllers/Application.scala
+++ b/web/app/controllers/Application.scala
@@ -18,7 +18,7 @@ object Application extends Controller {
     jsResult match {
       case JsSuccess(ns, _) =>
         val result = ns.map { n =>
-          Json.parse(snp.renderCompactJson(snp.fromString(n)))
+          Json.parse(snp.fromString(n).renderCompactJson)
         }
         Ok(obj(Messages.RESULT  -> Messages.RESULT_OK,
                Messages.DETAILS -> result))
@@ -37,7 +37,7 @@ object Application extends Controller {
         Array.empty[String]
       } else {
         rs.body.split("\r\n")
-          .map { name => snp.renderCompactJson(snp.fromString(name)) }
+          .map { name => snp.fromString(name).renderCompactJson }
       }
     Ok(views.html.index(searchForm, rs.body, res))
   }


### PR DESCRIPTION
fix #176 

The core change is move `json` and `renderCompactJson` to `Result` class via `JsonRender` trait. Everything else is consequences. 