### PR TITLE
= Add cross-build facility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: scala
 jdk:
   - oraclejdk8
-scala:
-  - 2.10.3
-  - 2.11.0
-  - 2.11.7
+script:
+  - sbt +test
 sudo: false

--- a/build.sbt
+++ b/build.sbt
@@ -71,6 +71,9 @@ val specs2core  = "org.specs2"         %% "specs2-core"            % "3.6.3" % T
 lazy val root = project.in(file("."))
   .aggregate(parser, examples, runner, web)
   .settings(noPublishingSettings: _*)
+  .settings(
+    crossScalaVersions := Seq("2.10.3", "2.11.7")
+  )
 
 lazy val parser = (project in file("./parser"))
   .enablePlugins(BuildInfoPlugin)


### PR DESCRIPTION
BTW those changes triples speed of build time at travis: testing container is composed only once, as well as dependencies are downloaded once of all supported scala versions.