### PR TITLE
Fix #384: correctly parse `str.` for `strain` in name

### DIFF
--- a/parser/src/main/scala/org/globalnames/parser/Preprocessor.scala
+++ b/parser/src/main/scala/org/globalnames/parser/Preprocessor.scala
@@ -22,12 +22,10 @@ object Preprocessor {
 
   private final val substitutionsPatterns = {
     val notes = """(?ix)\s+(species\s+group|species\s+complex|group|author|emend)\b.*$"""
-    val taxonConcepts1 = """(?i)\s+(sensu|auct|sec|near)\.?\b.*$"""
-    val taxonConcepts2 = """(?x)(,\s*|\s+)
-                            (\(?s\.\s?s\.|
-                            \(?s\.\s?l\.|
-                            \(?s\.\s?str\.|
-                            \(?s\.\s?lat\.).*$"""
+    val taxonConcepts1 = """(?i)\s+(sensu|auct|sec|near|str)\.?\b.*$"""
+    val taxonConcepts2 =
+      """(?x)(,\s*|\s+)
+        |(\(?s\.\s?s\.|\(?s\.\s?l\.|\(?s\.\s?str\.|\(?s\.\s?lat\.).*$""".stripMargin
     val taxonConcepts3 = """(?i)(,\s*|\s+)(pro parte|p\.\s?p\.)\s*$"""
     val nomenConcepts = """(?i)(,\s*|\s+)(\(?nomen|\(?nom\.|\(?comb\.).*$"""
     val lastWordJunk = """(?ix)(,\s*|\s+)

--- a/parser/src/test/resources/test_data.txt
+++ b/parser/src/test/resources/test_data.txt
@@ -24,6 +24,12 @@
 
 ### Uninomials
 
+### TODO <<<
+Methanosarcina barkeri str. fusaro
+{"name_string_id":"b1d6747d-6aa3-5b7a-a8ed-7ca53c4b19ac","parsed":true,"quality":2,"quality_warnings":[[2,"Name had to be changed by preprocessing"]],"parser_version":"test_version","verbatim":"Methanosarcina barkeri str. fusaro","normalized":"Methanosarcina barkeri","canonical_name":{"value":"Methanosarcina barkeri","value_ranked":"Methanosarcina barkeri"},"hybrid":false,"surrogate":false,"virus":false,"bacteria":false,"details":[{"genus":{"value":"Methanosarcina"},"specific_epithet":{"value":"barkeri"}}],"positions":[["genus",0,14],["specific_epithet",15,22]]}
+b1d6747d-6aa3-5b7a-a8ed-7ca53c4b19ac|Methanosarcina barkeri str. fusaro|Methanosarcina barkeri|Methanosarcina barkeri|||2
+### >>>
+
 #SECTION: Uninomial<
 Pseudocercospora
 {"name_string_id":"9c1167ca-79e7-53de-b4c3-fcdb68410527","parsed":true,"quality":1,"parser_version":"test_version","verbatim":"Pseudocercospora","normalized":"Pseudocercospora","canonical_name":{"value":"Pseudocercospora","value_ranked":"Pseudocercospora"},"hybrid":false,"surrogate":false,"virus":false,"bacteria":false,"details":[{"uninomial":{"value":"Pseudocercospora"}}],"positions":[["uninomial",0,16]]}

--- a/parser/src/test/resources/test_data.txt
+++ b/parser/src/test/resources/test_data.txt
@@ -24,12 +24,6 @@
 
 ### Uninomials
 
-### TODO <<<
-Methanosarcina barkeri str. fusaro
-{"name_string_id":"b1d6747d-6aa3-5b7a-a8ed-7ca53c4b19ac","parsed":true,"quality":2,"quality_warnings":[[2,"Name had to be changed by preprocessing"]],"parser_version":"test_version","verbatim":"Methanosarcina barkeri str. fusaro","normalized":"Methanosarcina barkeri","canonical_name":{"value":"Methanosarcina barkeri","value_ranked":"Methanosarcina barkeri"},"hybrid":false,"surrogate":false,"virus":false,"bacteria":false,"details":[{"genus":{"value":"Methanosarcina"},"specific_epithet":{"value":"barkeri"}}],"positions":[["genus",0,14],["specific_epithet",15,22]]}
-b1d6747d-6aa3-5b7a-a8ed-7ca53c4b19ac|Methanosarcina barkeri str. fusaro|Methanosarcina barkeri|Methanosarcina barkeri|||2
-### >>>
-
 #SECTION: Uninomial<
 Pseudocercospora
 {"name_string_id":"9c1167ca-79e7-53de-b4c3-fcdb68410527","parsed":true,"quality":1,"parser_version":"test_version","verbatim":"Pseudocercospora","normalized":"Pseudocercospora","canonical_name":{"value":"Pseudocercospora","value_ranked":"Pseudocercospora"},"hybrid":false,"surrogate":false,"virus":false,"bacteria":false,"details":[{"uninomial":{"value":"Pseudocercospora"}}],"positions":[["uninomial",0,16]]}
@@ -1040,6 +1034,10 @@ f3752c09-242f-501c-8c8c-0feaf86c4693|Parus caeruleus species complex|Parus caeru
 Chlorobium phaeobacteroides Pfennig, 1968 emend. Imhoff, 2003
 {"name_string_id":"4513701d-e56b-54d6-84a7-941bf4b62e69","parsed":true,"quality":2,"quality_warnings":[[2,"Name had to be changed by preprocessing"]],"parser_version":"test_version","verbatim":"Chlorobium phaeobacteroides Pfennig, 1968 emend. Imhoff, 2003","normalized":"Chlorobium phaeobacteroides Pfennig 1968","canonical_name":{"value":"Chlorobium phaeobacteroides","value_ranked":"Chlorobium phaeobacteroides"},"hybrid":false,"surrogate":false,"virus":false,"bacteria":true,"details":[{"genus":{"value":"Chlorobium"},"specific_epithet":{"value":"phaeobacteroides","authorship":{"value":"Pfennig 1968","basionym_authorship":{"authors":["Pfennig"],"year":{"value":"1968"}}}}}],"positions":[["genus",0,10],["specific_epithet",11,27],["author_word",28,35],["year",37,41]]}
 4513701d-e56b-54d6-84a7-941bf4b62e69|Chlorobium phaeobacteroides Pfennig, 1968 emend. Imhoff, 2003|Chlorobium phaeobacteroides|Chlorobium phaeobacteroides|Pfennig 1968|1968|2
+
+Methanosarcina barkeri str. fusaro
+{"name_string_id":"b1d6747d-6aa3-5b7a-a8ed-7ca53c4b19ac","parsed":true,"quality":2,"quality_warnings":[[2,"Name had to be changed by preprocessing"]],"parser_version":"test_version","verbatim":"Methanosarcina barkeri str. fusaro","normalized":"Methanosarcina barkeri","canonical_name":{"value":"Methanosarcina barkeri","value_ranked":"Methanosarcina barkeri"},"hybrid":false,"surrogate":false,"virus":false,"bacteria":false,"details":[{"genus":{"value":"Methanosarcina"},"specific_epithet":{"value":"barkeri"}}],"positions":[["genus",0,14],["specific_epithet",15,22]]}
+b1d6747d-6aa3-5b7a-a8ed-7ca53c4b19ac|Methanosarcina barkeri str. fusaro|Methanosarcina barkeri|Methanosarcina barkeri|||2
 #>
 
 #SECTION: Ignoring sensu sec<


### PR DESCRIPTION
Fix #384 